### PR TITLE
Lock coffee-script-source to 1.8.0 to stop server error when running …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'coffee-rails', '4.2.2'
 gem 'jquery-rails', '4.3.1'
 gem 'turbolinks',   '5.0.1'
 gem 'jbuilder',     '2.7.0'
+gem 'coffee-script-source', '1.8.0'
 
 group :development, :test do
   gem 'sqlite3', '1.3.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.12.2)
+    coffee-script-source (1.8.0)
     concurrent-ruby (1.0.5)
     erubi (1.6.1)
     execjs (2.7.0)
@@ -162,6 +162,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (= 9.0.6)
   coffee-rails (= 4.2.2)
+  coffee-script-source (= 1.8.0)
   jbuilder (= 2.7.0)
   jquery-rails (= 4.3.1)
   listen (= 3.0.8)


### PR DESCRIPTION
…on windows when specifying application style sheet